### PR TITLE
FIx beta test runner

### DIFF
--- a/.github/workflows/cypress-tests-beta.yml
+++ b/.github/workflows/cypress-tests-beta.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run Cypress Tests
         if: ${{ github.repository == 'newfold-labs/wp-plugin-mojo' }}
-        run: npm run test:e2e -- --browser chrome --tag "mojo, wp-beta"
+        run: npm run test:e2e -- --browser chrome
 
       - name: Store screenshots of test failures
         if: failure()


### PR DESCRIPTION
When running Cypress tests, we can't add the `--tag` flag if not passing `--record`. This PR removes the `--tag` flag to fix the failing test runner.