### PR TITLE
Add/redirects for old plugin urls

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -232,9 +232,10 @@ final class Admin {
 
 	/**
 	 * Old Mojo Url ids
+	 *
 	 * @return array
 	 */
-	public static function get_old_url_ids(){
+	public static function get_old_url_ids() {
 		return array(
 			'mojo-marketplace',
 			'mojo-performance',
@@ -254,7 +255,7 @@ final class Admin {
 	 */
 	public static function old_admin_pages() {
 		// Add old plugin pages (for redirecting)
-		foreach( self::get_old_url_ids() as $id ) {
+		foreach ( self::get_old_url_ids() as $id ) {
 			\add_menu_page(
 				__( 'MOJO', 'wp-plugin-mojo' ),
 				__( 'MOJO', 'wp-plugin-mojo' ),
@@ -273,10 +274,9 @@ final class Admin {
 	 */
 	public static function old_admin_redirect() {
 		global $pagenow;
-		if ( $pagenow == 'admin.php' && in_array( $_GET['page'], self::get_old_url_ids() ) ) {
+		if ( $pagenow === 'admin.php' && in_array( $_GET['page'], self::get_old_url_ids() ) ) {
 			wp_redirect( admin_url( 'admin.php?page=mojo' ) );
 			exit;
 		}
 	}
-
 } // END \MOJO\Admin

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -274,7 +274,7 @@ final class Admin {
 	 */
 	public static function old_admin_redirect() {
 		global $pagenow;
-		if ( $pagenow === 'admin.php' && in_array( $_GET['page'], self::get_old_url_ids() ) ) {
+		if ( 'admin.php' === $pagenow && in_array( $_GET['page'], self::get_old_url_ids() ) ) {
 			wp_redirect( admin_url( 'admin.php?page=mojo' ) );
 			exit;
 		}

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -29,6 +29,9 @@ final class Admin {
 		\add_action( 'admin_head', array( __CLASS__, 'admin_nav_style' ) );
 		/* Add runtime for data store */
 		\add_filter( 'newfold_runtime', array( __CLASS__, 'add_to_runtime' ) );
+		/* Add redirect from old url */
+		\add_action( 'admin_menu', array( __CLASS__, 'old_admin_pages' ) );
+		\add_action( 'admin_init', array( __CLASS__, 'old_admin_redirect' ) );
 
 		if ( isset( $_GET['page'] ) && strpos( filter_input( INPUT_GET, 'page', FILTER_UNSAFE_RAW ), 'mojo' ) >= 0 ) { // phpcs:ignore
 			\add_action( 'admin_footer_text', array( __CLASS__, 'add_brand_to_admin_footer' ) );
@@ -226,4 +229,53 @@ final class Admin {
 		$footer_text = \sprintf( \__( 'Thank you for creating with <a href="https://wordpress.org/">WordPress</a> and <a href="https://mojomarketplace.com/about">MOJO</a>.', 'wp-plugin-mojo' ) );
 		return $footer_text;
 	}
+
+	/**
+	 * Old Mojo Url ids
+	 * @return array
+	 */
+	public static function get_old_url_ids(){
+		return array(
+			'mojo-marketplace',
+			'mojo-performance',
+			'mojo-staging',
+			'mojo-home',
+			'mojo-hosting-panel',
+			'mojo-jetpack-connect-bounce'
+		);
+	}
+
+	/**
+	 * Keep dummy links for old admin pages
+	 * so we can redirect to the new page.
+	 *
+	 * @return void
+	 */
+	public static function old_admin_pages() {
+		// Add old plugin pages (for redirecting)
+		foreach( self::get_old_url_ids() as $id ) {
+			\add_menu_page(
+				__( 'MOJO', 'wp-plugin-mojo' ),
+				__( 'MOJO', 'wp-plugin-mojo' ),
+				'manage_options',
+				$id,
+				false
+			);
+		}
+	}
+
+	/**
+	 * Redirect old admin page to new admin page,
+	 * only applies on first nav click after update or a bookmark.
+	 *
+	 * @return void
+	 */
+	public static function old_admin_redirect() {
+		global $pagenow;
+		if ( $pagenow == 'admin.php' && in_array( $_GET['page'], self::get_old_url_ids() ) ) {
+			wp_redirect( admin_url( 'admin.php?page=mojo' ) );
+			exit;
+		}
+	}
+
 } // END \MOJO\Admin

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -241,7 +241,8 @@ final class Admin {
 			'mojo-staging',
 			'mojo-home',
 			'mojo-hosting-panel',
-			'mojo-jetpack-connect-bounce'
+			'mojo-jetpack-connect-bounce',
+			'mojo-marketplace-page',
 		);
 	}
 

--- a/languages/wp-plugin-mojo.pot
+++ b/languages/wp-plugin-mojo.pot
@@ -103,8 +103,8 @@ msgstr ""
 
 #: inc/Admin.php:118
 #: inc/Admin.php:119
-#: inc/Admin.php:258
 #: inc/Admin.php:259
+#: inc/Admin.php:260
 msgid "MOJO"
 msgstr ""
 

--- a/languages/wp-plugin-mojo.pot
+++ b/languages/wp-plugin-mojo.pot
@@ -103,8 +103,8 @@ msgstr ""
 
 #: inc/Admin.php:118
 #: inc/Admin.php:119
-#: inc/Admin.php:259
 #: inc/Admin.php:260
+#: inc/Admin.php:261
 msgid "MOJO"
 msgstr ""
 

--- a/languages/wp-plugin-mojo.pot
+++ b/languages/wp-plugin-mojo.pot
@@ -74,51 +74,53 @@ msgstr ""
 msgid "Preview the coming soon landing page"
 msgstr ""
 
-#: inc/Admin.php:58
-#: inc/Admin.php:212
+#: inc/Admin.php:61
+#: inc/Admin.php:215
 #: build/3.2.0/index.js:1
 msgid "Home"
 msgstr ""
 
-#: inc/Admin.php:61
+#: inc/Admin.php:64
 #: build/3.2.0/index.js:1
 msgid "Marketplace"
 msgstr ""
 
-#: inc/Admin.php:66
+#: inc/Admin.php:69
 #: build/3.2.0/index.js:1
 msgid "Performance"
 msgstr ""
 
-#: inc/Admin.php:70
-#: inc/Admin.php:213
+#: inc/Admin.php:73
+#: inc/Admin.php:216
 #: build/3.2.0/index.js:1
 msgid "Settings"
 msgstr ""
 
-#: inc/Admin.php:73
+#: inc/Admin.php:76
 #: build/3.2.0/index.js:1
 msgid "Help"
 msgstr ""
 
-#: inc/Admin.php:115
-#: inc/Admin.php:116
+#: inc/Admin.php:118
+#: inc/Admin.php:119
+#: inc/Admin.php:258
+#: inc/Admin.php:259
 msgid "MOJO"
 msgstr ""
 
-#: inc/Admin.php:158
+#: inc/Admin.php:161
 msgid "Please update to a newer WordPress version."
 msgstr ""
 
-#: inc/Admin.php:159
+#: inc/Admin.php:162
 msgid "There are new WordPress components which this plugin requires in order to render the interface."
 msgstr ""
 
-#: inc/Admin.php:160
+#: inc/Admin.php:163
 msgid "Please update now"
 msgstr ""
 
-#: inc/Admin.php:226
+#: inc/Admin.php:229
 msgid "Thank you for creating with <a href=\"https://wordpress.org/\">WordPress</a> and <a href=\"https://mojomarketplace.com/about\">MOJO</a>."
 msgstr ""
 


### PR DESCRIPTION
## Proposed changes

Adds a list of admin URLs from the old plugin and redirects to ensure users don't hit a snag on the update screen or via old bookmarks in their site admins.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
